### PR TITLE
Replace WDF with WDM (update 3)

### DIFF
--- a/HyperPlatform/Directory.build.props
+++ b/HyperPlatform/Directory.build.props
@@ -1,0 +1,14 @@
+<!-- 
+    Workaround to MSB8040:
+    Spectre-mitigated libraries are required for this project. Install them from the Visual Studio installer (Individual components tab) for any toolsets and architectures being used. 
+	
+	Learn more: https://aka.ms/Ofhn4c
+	C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Microsoft\VC\v160\Microsoft.CppBuild.targets	
+	425	
+-->
+
+<Project>
+  <PropertyGroup Label="Configuration">
+    <SpectreMitigation>false</SpectreMitigation>
+  </PropertyGroup>
+</Project>

--- a/HyperPlatform/HyperPlatform.inf
+++ b/HyperPlatform/HyperPlatform.inf
@@ -28,7 +28,6 @@ HKR,,Icon,,-5
 
 [SourceDisksFiles]
 HyperPlatform.sys  = 1,,
-WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with SourceDisksNames
 
 ;*****************************************
 ; Install Section
@@ -57,25 +56,6 @@ ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
 StartType      = 3               ; SERVICE_DEMAND_START
 ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %12%\HyperPlatform.sys
-
-;
-;--- HyperPlatform_Device Coinstaller installation ------
-;
-
-[HyperPlatform_Device.NT.CoInstallers]
-AddReg=HyperPlatform_Device_CoInstaller_AddReg
-CopyFiles=HyperPlatform_Device_CoInstaller_CopyFiles
-
-[HyperPlatform_Device_CoInstaller_AddReg]
-HKR,,CoInstallers32,0x00010000, "WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll,WdfCoInstaller"
-
-[HyperPlatform_Device_CoInstaller_CopyFiles]
-WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll
-
-[HyperPlatform_Device.NT.Wdf]
-KmdfService =  HyperPlatform, HyperPlatform_wdfsect
-[HyperPlatform_wdfsect]
-KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
 SPSVCINST_ASSOCSERVICE= 0x00000002

--- a/HyperPlatform/HyperPlatform.vcxproj
+++ b/HyperPlatform/HyperPlatform.vcxproj
@@ -26,7 +26,6 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>HyperPlatform</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -50,20 +49,19 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-    <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverType>WDM</DriverType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows7</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-    <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverType>WDM</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -121,6 +119,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories> $(DDK_INC_PATH);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link />
     <Link>
@@ -129,6 +128,14 @@
     <Inf>
       <KmdfVersionNumber />
     </Inf>
+    <MASM>
+      <ListAllAvailableInformation>true</ListAllAvailableInformation>
+    </MASM>
+    <MASM>
+      <EnableAssemblyGeneratedCodeListing>
+      </EnableAssemblyGeneratedCodeListing>
+      <AdditionalOptions />
+    </MASM>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -184,6 +191,15 @@
     <MASM Include="Arch\x64\x64.asm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <FileType>Document</FileType>
+      <AssembledCodeListingFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </AssembledCodeListingFile>
+      <ListAllAvailableInformation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </ListAllAvailableInformation>
+      <EnableAssemblyGeneratedCodeListing Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </EnableAssemblyGeneratedCodeListing>
+      <PerformSyntaxCheckOnly Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </PerformSyntaxCheckOnly>
     </MASM>
     <MASM Include="Arch\x86\x86.asm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -199,6 +215,5 @@
     <None Include="HyperPlatform.ruleset" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/HyperPlatform/HyperPlatform.vcxproj
+++ b/HyperPlatform/HyperPlatform.vcxproj
@@ -121,7 +121,6 @@
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
-    <Link />
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
     </Link>
@@ -141,7 +140,6 @@
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
-    <Link />
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
     </Link>

--- a/HyperPlatform/HyperPlatform.vcxproj
+++ b/HyperPlatform/HyperPlatform.vcxproj
@@ -66,7 +66,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
@@ -192,14 +191,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <FileType>Document</FileType>
-      <AssembledCodeListingFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </AssembledCodeListingFile>
-      <ListAllAvailableInformation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </ListAllAvailableInformation>
-      <EnableAssemblyGeneratedCodeListing Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </EnableAssemblyGeneratedCodeListing>
-      <PerformSyntaxCheckOnly Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </PerformSyntaxCheckOnly>
     </MASM>
     <MASM Include="Arch\x86\x86.asm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>

--- a/HyperPlatform/HyperPlatform.vcxproj
+++ b/HyperPlatform/HyperPlatform.vcxproj
@@ -26,6 +26,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>HyperPlatform</RootNamespace>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -51,6 +52,7 @@
     <ConfigurationType>Driver</ConfigurationType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
+    <_NT_TARGET_VERSION>0x0601</_NT_TARGET_VERSION>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows7</TargetVersion>
@@ -116,9 +118,8 @@
       <WppKernelMode>true</WppKernelMode>
       <SupportJustMyCode>false</SupportJustMyCode>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories> $(DDK_INC_PATH);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link />
     <Link>
@@ -130,11 +131,6 @@
     <MASM>
       <ListAllAvailableInformation>true</ListAllAvailableInformation>
     </MASM>
-    <MASM>
-      <EnableAssemblyGeneratedCodeListing>
-      </EnableAssemblyGeneratedCodeListing>
-      <AdditionalOptions />
-    </MASM>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -142,8 +138,8 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <WppKernelMode>true</WppKernelMode>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link />
     <Link>

--- a/HyperPlatform/HyperPlatform.vcxproj
+++ b/HyperPlatform/HyperPlatform.vcxproj
@@ -26,6 +26,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>HyperPlatform</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -33,7 +34,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-    <DriverType>KMDF</DriverType>
+    <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -41,7 +42,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-    <DriverType>KMDF</DriverType>
+    <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -49,7 +50,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-    <DriverType>KMDF</DriverType>
+    <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -57,7 +58,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-    <DriverType>KMDF</DriverType>
+    <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -122,6 +123,12 @@
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link />
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+    <Inf>
+      <KmdfVersionNumber />
+    </Inf>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -133,6 +140,12 @@
       <DisableSpecificWarnings>5040;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link />
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+    <Inf>
+      <KmdfVersionNumber />
+    </Inf>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />

--- a/HyperPlatform/HyperPlatform.vcxproj.filters
+++ b/HyperPlatform/HyperPlatform.vcxproj.filters
@@ -51,11 +51,11 @@
     <ClCompile Include="global_object.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="hotplug_callback.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="power_callback.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="hotplug_callback.cpp">
+      <Filter>Header Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/HyperPlatform/HyperPlatform.vcxproj.filters
+++ b/HyperPlatform/HyperPlatform.vcxproj.filters
@@ -55,7 +55,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="hotplug_callback.cpp">
-      <Filter>Header Files</Filter>
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/HyperPlatform/common.h
+++ b/HyperPlatform/common.h
@@ -35,7 +35,7 @@
 #ifndef HYPERPLATFORM_COMMON_H_
 #define HYPERPLATFORM_COMMON_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 // C30030: Calling a memory allocating function and passing a parameter that
 // indicates executable memory

--- a/HyperPlatform/common.h
+++ b/HyperPlatform/common.h
@@ -35,10 +35,6 @@
 #ifndef HYPERPLATFORM_COMMON_H_
 #define HYPERPLATFORM_COMMON_H_
 
-#if (_MSC_VER >= 1915)
-#define no_init_all deprecated
-#endif
-
 #include <ntddk.h>
 
 // C30030: Calling a memory allocating function and passing a parameter that

--- a/HyperPlatform/common.h
+++ b/HyperPlatform/common.h
@@ -35,6 +35,10 @@
 #ifndef HYPERPLATFORM_COMMON_H_
 #define HYPERPLATFORM_COMMON_H_
 
+#if (_MSC_VER >= 1915)
+#define no_init_all deprecated
+#endif
+
 #include <ntddk.h>
 
 // C30030: Calling a memory allocating function and passing a parameter that

--- a/HyperPlatform/ept.h
+++ b/HyperPlatform/ept.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_EPT_H_
 #define HYPERPLATFORM_EPT_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////////

--- a/HyperPlatform/global_object.h
+++ b/HyperPlatform/global_object.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_GLOBAL_OBJECT_H_
 #define HYPERPLATFORM_GLOBAL_OBJECT_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////////

--- a/HyperPlatform/hotplug_callback.h
+++ b/HyperPlatform/hotplug_callback.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_HOTPLUG_CALLBACK_H_
 #define HYPERPLATFORM_HOTPLUG_CALLBACK_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////////

--- a/HyperPlatform/ia32_type.h
+++ b/HyperPlatform/ia32_type.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_IA32_TYPE_H_
 #define HYPERPLATFORM_IA32_TYPE_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/HyperPlatform/kernel_stl.cpp
+++ b/HyperPlatform/kernel_stl.cpp
@@ -5,7 +5,7 @@
 /// @file
 /// Implements code to use STL in a driver project
 
-#include <fltKernel.h>
+#include <ntddk.h>
 #undef _HAS_EXCEPTIONS
 #define _HAS_EXCEPTIONS 0
 

--- a/HyperPlatform/log.cpp
+++ b/HyperPlatform/log.cpp
@@ -5,6 +5,7 @@
 /// @file
 /// Implements logging functions.
 
+#include <ntifs.h>
 #include "log.h"
 #define NTSTRSAFE_NO_CB_FUNCTIONS
 #include <ntstrsafe.h>

--- a/HyperPlatform/log.h
+++ b/HyperPlatform/log.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_LOG_H_
 #define HYPERPLATFORM_LOG_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////////

--- a/HyperPlatform/perf_counter.h
+++ b/HyperPlatform/perf_counter.h
@@ -14,7 +14,7 @@
 #ifndef HYPERPLATFORM_PERF_COUNTER_H_
 #define HYPERPLATFORM_PERF_COUNTER_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/HyperPlatform/power_callback.h
+++ b/HyperPlatform/power_callback.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_POWER_CALLBACK_H_
 #define HYPERPLATFORM_POWER_CALLBACK_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////////

--- a/HyperPlatform/util.cpp
+++ b/HyperPlatform/util.cpp
@@ -194,7 +194,7 @@ _Use_decl_annotations_ static NTSTATUS UtilpInitializePageTableVariables() {
   // older than build 14316.
   if (!IsX64() || os_version.dwMajorVersion < 10 ||
       os_version.dwBuildNumber < 14316) {
-    if constexpr (IsX64()) {
+    if (IsX64()) {
       g_utilp_pxe_base = kUtilpPxeBase;
       g_utilp_ppe_base = kUtilpPpeBase;
       g_utilp_pxi_shift = kUtilpPxiShift;
@@ -519,7 +519,7 @@ _Use_decl_annotations_ bool UtilIsAccessibleAddress(void *address) {
     return false;
   }
 
-  if constexpr (IsX64()) {
+  if (IsX64()) {
     const auto pxe = UtilpAddressToPxe(address);
     const auto ppe = UtilpAddressToPpe(address);
     if (!pxe->valid || !ppe->valid) {
@@ -543,7 +543,7 @@ _Use_decl_annotations_ bool UtilIsAccessibleAddress(void *address) {
 
 // Checks whether the address is the canonical address
 _Use_decl_annotations_ static bool UtilpIsCanonicalFormAddress(void *address) {
-  if constexpr (!IsX64()) {
+  if (!IsX64()) {
     return true;
   } else {
     return !UtilIsInBounds(0x0000800000000000ull, 0xffff7fffffffffffull,

--- a/HyperPlatform/util.cpp
+++ b/HyperPlatform/util.cpp
@@ -521,12 +521,10 @@ _Use_decl_annotations_ bool UtilIsAccessibleAddress(void *address) {
 
 // UtilpAddressToPxe, UtilpAddressToPpe defined for x64
 #if defined(_AMD64_)
-  if (IsX64()) {
-    const auto pxe = UtilpAddressToPxe(address);
-    const auto ppe = UtilpAddressToPpe(address);
-    if (!pxe->valid || !ppe->valid) {
-      return false;
-    }
+  const auto pxe = UtilpAddressToPxe(address);
+  const auto ppe = UtilpAddressToPpe(address);
+  if (!pxe->valid || !ppe->valid) {
+    return false;
   }
 #endif
 

--- a/HyperPlatform/util.cpp
+++ b/HyperPlatform/util.cpp
@@ -50,31 +50,42 @@ _Must_inspect_result_ _IRQL_requires_max_(DISPATCH_LEVEL) NTKERNELAPI
 using MmAllocateContiguousNodeMemoryType =
     decltype(MmAllocateContiguousNodeMemory);
 
-// from Windows Research Kernel v1.2
-// stable fields for Win 7+
+//
+// DRIVER_OBJECT.DriverSection type
+// see Reverse Engineering site:
+// https://revers.engineering/author/daax/
+//
 struct KLdrDataTableEntry {
-  LIST_ENTRY in_load_order_links;
-  PVOID exception_table;
-  ULONG exception_table_size;
-  // ULONG padding on IA64
-  PVOID gp_value;
-  // ntimage.h
-  PNON_PAGED_DEBUG_INFO non_paged_debug_info;
-  PVOID dll_base;
-  PVOID entry_point;
-  ULONG size_of_image;
-  UNICODE_STRING full_dll_name;
-  UNICODE_STRING base_dll_name;
-  ULONG flags;
-  USHORT load_count;
-  USHORT __Unused5;
-  PVOID section_pointer;
-  ULONG checksum;
-  // ULONG padding on IA64
-  PVOID loaded_imports;
-  PVOID patch_information;
-  // Expanded in Windows 10
-};
+    LIST_ENTRY in_load_order_links;
+    PVOID exception_table;
+    UINT32 exception_table_size;
+    // ULONG padding on IA64
+    PVOID gp_value;
+    PNON_PAGED_DEBUG_INFO non_paged_debug_info;
+    PVOID dll_base;
+    PVOID entry_point;
+    UINT32 size_of_image;
+    UNICODE_STRING full_dll_name;
+    UNICODE_STRING base_dll_name;
+    UINT32 flags;
+    UINT16 load_count;
+
+    union {
+      UINT16 signature_level : 4;
+      UINT16 signature_type : 3;
+      UINT16 unused : 9;
+      UINT16 entire_field;
+    } u;
+
+    PVOID section_pointer;
+    UINT32 checksum;
+    UINT32 coverage_section_size;
+    PVOID coverage_section;
+    PVOID loaded_imports;
+    PVOID spare;
+    UINT32 size_of_image_not_rouned;
+    UINT32 time_date_stamp;
+ };
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/HyperPlatform/util.cpp
+++ b/HyperPlatform/util.cpp
@@ -519,6 +519,8 @@ _Use_decl_annotations_ bool UtilIsAccessibleAddress(void *address) {
     return false;
   }
 
+// UtilpAddressToPxe, UtilpAddressToPpe defined for x64
+#if defined(_AMD64_)
   if (IsX64()) {
     const auto pxe = UtilpAddressToPxe(address);
     const auto ppe = UtilpAddressToPpe(address);
@@ -526,6 +528,7 @@ _Use_decl_annotations_ bool UtilIsAccessibleAddress(void *address) {
       return false;
     }
   }
+#endif
 
   const auto pde = UtilpAddressToPde(address);
   const auto pte = UtilpAddressToPte(address);

--- a/HyperPlatform/vm.cpp
+++ b/HyperPlatform/vm.cpp
@@ -450,7 +450,7 @@ _Use_decl_annotations_ static void VmpInitializeVm(
   // fields (Eip and HardwareEsp on x86, or Rip and Rsp on x64) is properly
   // initialized (in VmmVmExitHandler) and used by Windbg. On VM-exit this space
   // is just skipped by subtracting the stack pointer.
-  if constexpr (!IsReleaseBuild()) {
+  if (!IsReleaseBuild()) {
     const auto vmm_stack_frame =
         reinterpret_cast<void *>(vmm_stack_data - sizeof(KtrapFrame));
     RtlFillMemory(vmm_stack_frame, sizeof(KtrapFrame), 0xff);

--- a/HyperPlatform/vm.h
+++ b/HyperPlatform/vm.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_VM_H_
 #define HYPERPLATFORM_VM_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////////

--- a/HyperPlatform/vmm.cpp
+++ b/HyperPlatform/vmm.cpp
@@ -220,7 +220,7 @@ _Use_decl_annotations_ bool __stdcall VmmVmExitHandler(VmmInitialStack *stack) {
   }
 
   // Apply possibly updated CR8 by the handler
-  if constexpr (IsX64()) {
+  if (IsX64()) {
     __writecr8(guest_context.cr8);
   }
   return guest_context.vm_continue;
@@ -1494,7 +1494,7 @@ _Use_decl_annotations_ static void VmmpInjectInterruption(
 /*_Use_decl_annotations_*/ static ULONG_PTR VmmpGetKernelCr3() {
   ULONG_PTR guest_cr3 = 0;
   static const long kDirectoryTableBaseOffset = IsX64() ? 0x28 : 0x18;
-  if constexpr (IsX64()) {
+  if (IsX64()) {
     // On x64, assume it is an user-mode CR3 when the lowest bit is set. If so,
     // get CR3 from _KPROCESS::DirectoryTableBase.
     guest_cr3 = UtilVmRead(VmcsField::kGuestCr3);

--- a/HyperPlatform/vmm.h
+++ b/HyperPlatform/vmm.h
@@ -50,9 +50,9 @@ struct KtrapFrameX86 {
   ULONG sp;  //!< Called HardwareEsp in _KTRAP_FRAME
   ULONG reserved3[5];
 };
-static_assert(sizeof(KtrapFrameX86) == 0x8c, "");
-static_assert(FIELD_OFFSET(KtrapFrameX86, ip) == 0x68, "");
-static_assert(FIELD_OFFSET(KtrapFrameX86, sp) == 0x74, "");
+static_assert(sizeof(KtrapFrameX86) == 0x8c, "structure size mismatch");
+static_assert(FIELD_OFFSET(KtrapFrameX86, ip) == 0x68, "structure size mismatch");
+static_assert(FIELD_OFFSET(KtrapFrameX86, sp) == 0x74, "structure size mismatch");
 
 /// nt!_KTRAP_FRAME on x64
 struct KtrapFrameX64 {
@@ -62,9 +62,9 @@ struct KtrapFrameX64 {
   ULONG64 sp;  //!< Called Rsp in _KTRAP_FRAME
   ULONG64 reserved3;
 };
-static_assert(sizeof(KtrapFrameX64) == 0x190, "");
-static_assert(FIELD_OFFSET(KtrapFrameX64, ip) == 0x168, "");
-static_assert(FIELD_OFFSET(KtrapFrameX64, sp) == 0x180, "");
+static_assert(sizeof(KtrapFrameX64) == 0x190, "structure size mismatch");
+static_assert(FIELD_OFFSET(KtrapFrameX64, ip) == 0x168, "structure size mismatch");
+static_assert(FIELD_OFFSET(KtrapFrameX64, sp) == 0x180, "structure size mismatch");
 
 /// See: Stack Usage on Transfers to Interrupt and Exception-Handling Routines
 struct MachineFrame {

--- a/HyperPlatform/vmm.h
+++ b/HyperPlatform/vmm.h
@@ -8,7 +8,7 @@
 #ifndef HYPERPLATFORM_VMM_H_
 #define HYPERPLATFORM_VMM_H_
 
-#include <fltKernel.h>
+#include <ntddk.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -50,9 +50,9 @@ struct KtrapFrameX86 {
   ULONG sp;  //!< Called HardwareEsp in _KTRAP_FRAME
   ULONG reserved3[5];
 };
-static_assert(sizeof(KtrapFrameX86) == 0x8c);
-static_assert(FIELD_OFFSET(KtrapFrameX86, ip) == 0x68);
-static_assert(FIELD_OFFSET(KtrapFrameX86, sp) == 0x74);
+static_assert(sizeof(KtrapFrameX86) == 0x8c, "");
+static_assert(FIELD_OFFSET(KtrapFrameX86, ip) == 0x68, "");
+static_assert(FIELD_OFFSET(KtrapFrameX86, sp) == 0x74, "");
 
 /// nt!_KTRAP_FRAME on x64
 struct KtrapFrameX64 {
@@ -62,9 +62,9 @@ struct KtrapFrameX64 {
   ULONG64 sp;  //!< Called Rsp in _KTRAP_FRAME
   ULONG64 reserved3;
 };
-static_assert(sizeof(KtrapFrameX64) == 0x190);
-static_assert(FIELD_OFFSET(KtrapFrameX64, ip) == 0x168);
-static_assert(FIELD_OFFSET(KtrapFrameX64, sp) == 0x180);
+static_assert(sizeof(KtrapFrameX64) == 0x190, "");
+static_assert(FIELD_OFFSET(KtrapFrameX64, ip) == 0x168, "");
+static_assert(FIELD_OFFSET(KtrapFrameX64, sp) == 0x180, "");
 
 /// See: Stack Usage on Transfers to Interrupt and Exception-Handling Routines
 struct MachineFrame {


### PR DESCRIPTION
This pull-request removes dependencies on the Windows Driver Framework.   The resulting HyperPlatform.sys only has dependencies on ntoskrnl.exe and hal.dll.
